### PR TITLE
エラーハンドリングのセッションにリンクを追加

### DIFF
--- a/Documentation/Error.md
+++ b/Documentation/Error.md
@@ -12,15 +12,11 @@ Swiftにはベースになる考え方があります。
 
 ## 課題
 - 呼び出しAPIを`Throws ver`に変更する
-- エラーを Delegate で受け取る
 - 天気予報を画面に表示する
 - APIエラーが発生したらUIAlertControllerを表示する
   - エラーの内容に応じてメッセージを変更する  
   - メッセージの内容は自由ですが、[ヒューマンインターフェイスガイドラインのアラート](https://developer.apple.com/jp/design/human-interface-guidelines/alerts)の項目も読んでみましょう。エラーメッセージについては次の記事もあわせて読むとイメージが膨らむと思います
     - [本当に有意義なエラーメッセージを書くには](https://postd.cc/how-to-write-an-error-message/)
-
-## ヒント
-- CLLocationDelegate の例だと、 [locationManager(_:didFailWithError:)](https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate/1423786-locationmanager) でエラーを受け取ります
 
 ## 附録
 [関連ワード・動画索引（熊谷さんのやさしい Swift 勉強会）](https://yumemi.notion.site/0b948552bd89415c95e89e3ebe3811d6)

--- a/Documentation/Error.md
+++ b/Documentation/Error.md
@@ -16,7 +16,8 @@ Swiftにはベースになる考え方があります。
 - 天気予報を画面に表示する
 - APIエラーが発生したらUIAlertControllerを表示する
   - エラーの内容に応じてメッセージを変更する  
-  メッセージの内容は自由です。エラーを切り分けられていればOK。
+  - メッセージの内容は自由ですが、[ヒューマンインターフェイスガイドラインのアラート](https://developer.apple.com/jp/design/human-interface-guidelines/alerts)の項目も読んでみましょう。エラーメッセージについては次の記事もあわせて読むとイメージが膨らむと思います
+    - [本当に有意義なエラーメッセージを書くには](https://postd.cc/how-to-write-an-error-message/)
 
 ## ヒント
 - CLLocationDelegate の例だと、 [locationManager(_:didFailWithError:)](https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate/1423786-locationmanager) でエラーを受け取ります


### PR DESCRIPTION
下記の理由からリンクを追加しました。

- アラートの HIG も読んで推奨される使い方を学んでほしい
- エラーメッセージについて考察の記事を読んでより良いエラーメッセージについて考えてほしい